### PR TITLE
Add `.py`  to solve the issue #11.

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -107,7 +107,7 @@ recipe.size.regex.data=\s*[0-9]+\s+[0-9]+\s+[0-9]+\s+([0-9]+).*
 ## burntool_py
 
 tools.burntool_py.path={runtime.tools.burntool_py.path}
-tools.burntool_py.cmd=burntool
+tools.burntool_py.cmd=burntool.py
 tools.burntool_py.cmd.linux=burntool.py
 tools.burntool_py.cmd.windows=burntool.py
 


### PR DESCRIPTION
`.py` is added to solve the issue #11.

#11 shows we cannot upload a program to a duo-256m from Arduino IDE on macOS.
After adding `.py`, I succeeded in uploading my program to a duo-256m from Arduino IDE!
https://github.com/milkv-duo/duo-arduino/issues/11#issuecomment-2166276269

thanks,