### PR TITLE
Create a library for controlling a PWM signal from Arduino

### DIFF
--- a/cores/sg200x/ControlPWM.cpp
+++ b/cores/sg200x/ControlPWM.cpp
@@ -1,0 +1,45 @@
+#include "Arduino.h"
+#include "common.h"
+#include "csi_gpio_pin.h"
+#include "csi_pin.h"
+#include "csi_pwm.h"
+#include "wiring_analog.h"
+#include "ControlPWM.h"
+
+int channel = -1;
+static csi_pwm_t active_pwm_servo;
+extern dev_pin_map_t pwm_map[];
+
+void setPWM(uint8_t _pin, unsigned int _pulse, unsigned int _period)
+{
+    const dev_pin_map_t* pwm_pin = target_pin_number_to_dev(_pin, pwm_map, 0xFF);
+    if (pwm_pin == NULL) {
+        pr_err("pin GPIO %d is not used as PWM func\n", _pin);
+        return;
+    }
+
+    uint8_t pwm_idx = pwm_pin->idx >> 2;
+    uint8_t pwm_channel = pwm_pin->idx & 0x3;
+
+    if (csi_pin_set_mux(pwm_pin->name, pwm_pin->func)) {
+        pr_err("pin GPIO %d fails to config as PWM func\n", _pin);
+        return;
+    };
+
+    csi_error_t ret_status = csi_pwm_init(&active_pwm_servo, pwm_idx);
+    if (ret_status != CSI_OK) {
+        pr_err("GPIO pin %d init failed\n", _pin);
+        return;
+    }
+    channel = pwm_channel;
+
+    csi_pwm_out_stop(&active_pwm_servo, pwm_channel);
+    csi_pwm_out_config_continuous(&active_pwm_servo, pwm_channel, _period,
+                                   0, PWM_POLARITY_HIGH);
+    csi_pwm_out_start(&active_pwm_servo, pwm_channel);
+
+    csi_pwm_out_stop(&active_pwm_servo, pwm_channel);
+    csi_pwm_out_config_continuous(&active_pwm_servo, pwm_channel, _period,
+                                   _pulse, PWM_POLARITY_HIGH);
+    csi_pwm_out_start(&active_pwm_servo, pwm_channel);
+}

--- a/cores/sg200x/include/Arduino.h
+++ b/cores/sg200x/include/Arduino.h
@@ -48,6 +48,7 @@ void yield(void) __attribute__ ((weak, alias("__empty")));
 #include "HardwareSerial.h"
 #include "wiring_pulse.h"
 #include "Tone.h"
+#include "ControlPWM.h"
 
 #endif // __cplusplus
 

--- a/cores/sg200x/include/ControlPWM.h
+++ b/cores/sg200x/include/ControlPWM.h
@@ -1,0 +1,6 @@
+#ifndef _CONTROLPWM_H_
+#define _CONTROLPWM_H_
+
+extern void setPWM(uint8_t _pin, unsigned int _pulse, unsigned int _period);
+
+#endif /* _CONTROLPWM_H_ */


### PR DESCRIPTION
Hi, @carbonfix @shiptux 

I create a library for controlling a PWM signal.

A servo motor has usually been used on a robot , so whether milkv-duo can control the servo or not is crucial in deciding whether to use this microcontroller for developing the robot, I think.
Almost all servo motors require a PWM signal to be controlled.
Generally, `Servo.h` has been used when using a servo motor from Arduino IDE, but the library cannot be used on milkv-duo yet.
That’s why I created a cheap PWM library and issued this PR.

`setPWM` function can be used like the below program.
```ino
#define TEST_PIN     20
#define SERVO_0_PIN  12
#define SERVO_1_PIN   9

void setup() {
  pinMode( TEST_PIN, OUTPUT);
  pinMode( SERVO_0_PIN, OUTPUT);
  pinMode( SERVO_1_PIN, OUTPUT);
}

void loop() {
  setPWM( SERVO_0_PIN, 500, 20000); //rising a signal while 500us every 20000us
  delay(500);                  
  setPWM( SERVO_1_PIN, 500, 20000); //rising a signal while 500us every 20000us
  digitalWrite( TEST_PIN, HIGH); 
  delay(2000);                  

  setPWM( SERVO_0_PIN, 2400, 20000); //rising a signal while 2400us every 20000us
  setPWM( SERVO_1_PIN, 2400, 20000); //rising a signal while 2400us every 20000us
  digitalWrite( TEST_PIN, LOW);  
  delay(3000);                  
}
```

I posted the demo movie of controlling two servo motors `MG996` to X.
https://x.com/tnk_make/status/1804395404529930300

Best regards,