### PR TITLE
Fix Wire.cpp:

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -192,14 +192,19 @@ uint8_t TwoWire::endTransmission(bool stopBit)
         data[i++] = txBuffer.read_char();
     }
 
-    switch (csi_iic_master_send(&_iic, txAddress, data, i, _timeout, stopBit)) {
+    int ret = csi_iic_master_send(&_iic, txAddress, data, i, _timeout, stopBit);
+    switch (ret) {
     case CSI_OK:
         return 0;
     case CSI_TIMEOUT:
         return 5;
     default:
-        return 4;
+	if (ret > 0)
+            return 0;
+        else
+	    return 4;
     }
+
     return 0;
 }
 


### PR DESCRIPTION
Function csi_iic_master_send will return a real size of send count or a defined error code, so it will never return 0 or CSI_OK. Due to the return code which may be a number larger than 0, endTransmission will return 4, which means it is an “other error“ in Arduino convention.

Issue: https://github.com/milkv-duo/duo-buildroot-sdk/issues/118